### PR TITLE
Add gateway and accounts service scaffold with observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,44 @@
-# NeoStyle Demo Banking App
+# Neo Rewards Demo Monorepo
 
-This repository contains a demo banking application inspired by Neo Financial's customer portal. It follows a microservice architecture with GraphQL APIs.
+This repository hosts the **Neo Rewards Demo** project. It showcases a modular Apollo Federation architecture with a single MongoDB instance and a React client. The repo is designed to be Codex/AI friendly and mentoring ready.
 
-**Services**:
-- `auth-service`
-- `accounts-service`
-- `rewards-service`
-- `transfers-service`
+## Architecture Overview
 
-Each service is written in TypeScript using `graphql-yoga` and exposes a public GraphQL endpoint.
+- **Apollo Federation v2** with an Apollo Gateway and federated subgraph services
+- **Single MongoDB instance** for demo scope
+- **React + Vite client** using Apollo Client with generated hooks
+- **Shared skeleton package** providing configuration loaders, observability hooks, and utilities
+- **pnpm** workspaces managed by **TurboRepo**
 
-A `docker-compose.yml` file is provided for local development with MongoDB instances for dev and test environments.
+## Workspaces
 
-Run `npm install` in each service directory and start the stack with `docker-compose up`.
+- `packages/skeleton` – shared utilities and observability hooks
+- `packages/gateway` – Apollo Gateway composing subgraphs
+- `packages/accounts-service` – example federated service
+- `packages/auth-service` – to be implemented
+- `packages/rewards-service` – to be implemented
+- `packages/transfers-service` – to be implemented
+- `client` – React application
+
+## Development
+
+Use **pnpm** to install dependencies and **TurboRepo** to orchestrate builds. Each package can be built or started individually.
+
+```bash
+pnpm install
+pnpm --filter @neo-rewards/gateway run dev
+```
+
+Docker Compose provides local MongoDB instances for development and testing.
+
+## Code Generation
+
+GraphQL code generation outputs are committed to the repository. Services generate local resolver types and the client generates React hooks from the gateway schema. See `CODEGEN.md` for details.
+
+## Observability
+
+Observability plugins (tracing and structured logging with correlation IDs) are provided via the skeleton package and used by both services and the gateway.
+
+---
+
+This README and the accompanying architecture YAML are the authoritative source of truth for project conventions.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "neo-demo-pro-app",
   "private": true,
-  "workspaces": ["services/*"],
+  "workspaces": [
+    "services/*",
+    "packages/*",
+    "client"
+  ],
   "scripts": {
     "lint": "eslint .",
     "format": "prettier --write ."

--- a/packages/accounts-service/package.json
+++ b/packages/accounts-service/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@neo-rewards/accounts-service",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node src/index.ts"
+  },
+  "dependencies": {
+    "@apollo/server": "^4.7.4",
+    "@apollo/subgraph": "^2.5.2",
+    "express": "^4.18.2",
+    "mongodb": "^6.1.0",
+    "@neo-rewards/skeleton": "workspace:*",
+    "graphql-tag": "^2.12.6"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1"
+  }
+}

--- a/packages/accounts-service/src/graphql/resolvers/user.ts
+++ b/packages/accounts-service/src/graphql/resolvers/user.ts
@@ -1,0 +1,26 @@
+import { ObjectId, MongoClient, Db } from 'mongodb';
+
+interface UserDoc {
+  _id: ObjectId;
+  email: string;
+  name: string;
+}
+
+export function createResolvers(db: Db) {
+  const users = db.collection<UserDoc>('users');
+  return {
+    Query: {
+      async user(_: any, { id }: { id: string }) {
+        const user = await users.findOne({ _id: new ObjectId(id) });
+        return user ? { id: user._id.toHexString(), email: user.email, name: user.name } : null;
+      },
+    },
+    User: {
+      __resolveReference(ref: { id: string }) {
+        return users.findOne({ _id: new ObjectId(ref.id) }).then((u) =>
+          u ? { id: u._id.toHexString(), email: u.email, name: u.name } : null
+        );
+      },
+    },
+  };
+}

--- a/packages/accounts-service/src/graphql/schema/user.graphql
+++ b/packages/accounts-service/src/graphql/schema/user.graphql
@@ -1,0 +1,9 @@
+type User @key(fields: "id") {
+  id: ID!
+  email: String!
+  name: String!
+}
+
+type Query {
+  user(id: ID!): User
+}

--- a/packages/accounts-service/src/index.ts
+++ b/packages/accounts-service/src/index.ts
@@ -1,0 +1,41 @@
+import { ApolloServer } from '@apollo/server';
+import { expressMiddleware } from '@apollo/server/express4';
+import { buildSubgraphSchema } from '@apollo/subgraph';
+import { readFileSync } from 'fs';
+import path from 'path';
+import gql from 'graphql-tag';
+import { MongoClient } from 'mongodb';
+import express from 'express';
+import { createObservabilityPlugins } from '@neo-rewards/skeleton/src/observabilityHooks';
+import { createResolvers } from './graphql/resolvers/user';
+
+const typeDefs = gql(readFileSync(path.join(__dirname, 'graphql/schema/user.graphql'), 'utf8'));
+
+export async function createApp() {
+  const mongoUrl = process.env.MONGO_URL || 'mongodb://localhost:27017/accounts';
+  const client = new MongoClient(mongoUrl);
+  await client.connect();
+  const db = client.db();
+
+  const resolvers = createResolvers(db);
+  const schema = buildSubgraphSchema([{ typeDefs, resolvers }]);
+
+  const server = new ApolloServer({
+    schema,
+    plugins: createObservabilityPlugins(),
+  });
+  await server.start();
+
+  const app = express();
+  app.use('/graphql', express.json(), expressMiddleware(server));
+  return app;
+}
+
+if (require.main === module) {
+  createApp().then((app) => {
+    const port = process.env.PORT ? parseInt(process.env.PORT) : 4001;
+    app.listen(port, () => {
+      console.log(`accounts-service listening on ${port}`);
+    });
+  });
+}

--- a/packages/accounts-service/tsconfig.json
+++ b/packages/accounts-service/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@neo-rewards/gateway",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node src/index.ts"
+  },
+  "dependencies": {
+    "@apollo/server": "^4.7.4",
+    "@apollo/gateway": "^2.5.1",
+    "express": "^4.18.2",
+    "@neo-rewards/skeleton": "workspace:*"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1"
+  }
+}

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -1,0 +1,34 @@
+import { ApolloServer } from '@apollo/server';
+import { ApolloGateway } from '@apollo/gateway';
+import { expressMiddleware } from '@apollo/server/express4';
+import express from 'express';
+import { createObservabilityPlugins } from '@neo-rewards/skeleton/src/observabilityHooks';
+
+const gateway = new ApolloGateway({
+  serviceList: [
+    { name: 'accounts-service', url: 'http://localhost:4001/graphql' },
+    { name: 'auth-service', url: 'http://localhost:4002/graphql' },
+    { name: 'rewards-service', url: 'http://localhost:4003/graphql' },
+    { name: 'transfers-service', url: 'http://localhost:4004/graphql' },
+  ],
+});
+
+export async function createApp() {
+  const server = new ApolloServer({
+    gateway,
+    plugins: createObservabilityPlugins(),
+  });
+  await server.start();
+  const app = express();
+  app.use('/graphql', express.json(), expressMiddleware(server));
+  return app;
+}
+
+if (require.main === module) {
+  createApp().then((app) => {
+    const port = process.env.PORT ? parseInt(process.env.PORT) : 4000;
+    app.listen(port, () => {
+      console.log(`gateway listening on ${port}`);
+    });
+  });
+}

--- a/packages/gateway/tsconfig.json
+++ b/packages/gateway/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@neo-rewards/skeleton",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@apollo/server": "^4.7.4"
+  }
+}

--- a/packages/skeleton/src/observabilityHooks.ts
+++ b/packages/skeleton/src/observabilityHooks.ts
@@ -1,0 +1,26 @@
+import { ApolloServerPlugin, GraphQLRequestContext, GraphQLRequestListener } from '@apollo/server';
+import { ApolloServerPluginInlineTrace } from '@apollo/server/plugin/inlineTrace/index.js';
+import { randomUUID } from 'crypto';
+
+export function createObservabilityPlugins(): ApolloServerPlugin[] {
+  const loggingPlugin: ApolloServerPlugin = {
+    async requestDidStart(requestContext: GraphQLRequestContext<any>): Promise<GraphQLRequestListener> {
+      const start = Date.now();
+      const correlationId = requestContext.request.http?.headers.get('x-correlation-id') || randomUUID();
+      return {
+        async willSendResponse(ctx) {
+          const duration = Date.now() - start;
+          const log = {
+            correlationId,
+            operationName: ctx.operationName,
+            duration,
+            errors: ctx.errors?.map((e) => e.message),
+          };
+          console.log(JSON.stringify(log));
+        },
+      };
+    },
+  };
+
+  return [ApolloServerPluginInlineTrace(), loggingPlugin];
+}

--- a/packages/skeleton/tsconfig.json
+++ b/packages/skeleton/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,6 @@
     "forceConsistentCasingInFileNames": true,
     "outDir": "dist"
   },
-  "include": ["services/*/src/**/*"],
+  "include": ["services/*/src/**/*", "packages/*/src/**/*"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- scaffold `@neo-rewards/skeleton` observability hooks
- scaffold `@neo-rewards/gateway` using Apollo Gateway v2 and express
- scaffold `@neo-rewards/accounts-service` as a federated subgraph
- update root TS config and workspaces
- refresh README to outline the new architecture

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68437e79c0d883319156266480e86a16