### PR TITLE
Add codegen docs and adjust collections

### DIFF
--- a/CODEGEN.md
+++ b/CODEGEN.md
@@ -1,0 +1,7 @@
+# GraphQL Code Generation
+
+This repository uses `graphql-codegen` to generate TypeScript types and hooks.
+
+Run `pnpm generate` from the repository root or from individual packages to
+regenerate artifacts after changing GraphQL schemas. Generated files are
+committed to the repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing
+
+Thank you for your interest in contributing to this project.
+
+Please ensure `pnpm lint`, `pnpm format`, and any tests pass before submitting a
+pull request. If you modify GraphQL schemas, run `pnpm generate` so that codegen
+outputs remain up to date.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   ],
   "scripts": {
     "lint": "eslint .",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "generate": "graphql-codegen"
   },
   "devDependencies": {
     "eslint": "^8.56.0",

--- a/packages/accounts-service/package.json
+++ b/packages/accounts-service/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "dev": "ts-node src/index.ts"
+    "dev": "ts-node src/index.ts",
+    "generate": "graphql-codegen"
   },
   "dependencies": {
     "@apollo/server": "^4.7.4",

--- a/packages/accounts-service/src/graphql/resolvers/user.ts
+++ b/packages/accounts-service/src/graphql/resolvers/user.ts
@@ -7,19 +7,25 @@ interface UserDoc {
 }
 
 export function createResolvers(db: Db) {
-  const users = db.collection<UserDoc>('users');
+  const users = db.collection<UserDoc>('accounts_users');
   return {
     Query: {
       async user(_: any, { id }: { id: string }) {
         const user = await users.findOne({ _id: new ObjectId(id) });
-        return user ? { id: user._id.toHexString(), email: user.email, name: user.name } : null;
+        return user
+          ? { id: user._id.toHexString(), email: user.email, name: user.name }
+          : null;
       },
     },
     User: {
       __resolveReference(ref: { id: string }) {
-        return users.findOne({ _id: new ObjectId(ref.id) }).then((u) =>
-          u ? { id: u._id.toHexString(), email: u.email, name: u.name } : null
-        );
+        return users
+          .findOne({ _id: new ObjectId(ref.id) })
+          .then((u) =>
+            u
+              ? { id: u._id.toHexString(), email: u.email, name: u.name }
+              : null,
+          );
       },
     },
   };

--- a/packages/skeleton/src/index.ts
+++ b/packages/skeleton/src/index.ts
@@ -1,0 +1,1 @@
+export * from './observabilityHooks';

--- a/packages/skeleton/src/observabilityHooks.ts
+++ b/packages/skeleton/src/observabilityHooks.ts
@@ -1,16 +1,25 @@
-import { ApolloServerPlugin, GraphQLRequestContext, GraphQLRequestListener } from '@apollo/server';
+import {
+  ApolloServerPlugin,
+  GraphQLRequestContext,
+  GraphQLRequestListener,
+} from '@apollo/server';
 import { ApolloServerPluginInlineTrace } from '@apollo/server/plugin/inlineTrace/index.js';
 import { randomUUID } from 'crypto';
 
 export function createObservabilityPlugins(): ApolloServerPlugin[] {
   const loggingPlugin: ApolloServerPlugin = {
-    async requestDidStart(requestContext: GraphQLRequestContext<any>): Promise<GraphQLRequestListener> {
+    async requestDidStart(
+      requestContext: GraphQLRequestContext<any>,
+    ): Promise<GraphQLRequestListener> {
       const start = Date.now();
-      const correlationId = requestContext.request.http?.headers.get('x-correlation-id') || randomUUID();
+      const correlationId =
+        requestContext.request.http?.headers.get('x-correlation-id') ||
+        randomUUID();
       return {
         async willSendResponse(ctx) {
           const duration = Date.now() - start;
           const log = {
+            level: 'info',
             correlationId,
             operationName: ctx.operationName,
             duration,


### PR DESCRIPTION
## Summary
- update observability hooks with log level
- change Mongo collection name to `accounts_users`
- expose observability hooks from skeleton index
- add CODEGEN and CONTRIBUTING docs
- add `generate` script for codegen

## Testing
- `npm test` *(fails: Missing script)*
- `pnpm lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68438b8dd5dc8331b3c913152e7fd56a