### PR TITLE
Fix CODEOWNERS and scaffold skeleton config loader

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
-* @your-github-username
+* @desoleary
 
-/packages/skeleton/ @your-github-username
-/packages/gateway/ @your-github-username
-/packages/accounts-service/ @your-github-username
-/packages/auth-service/ @your-github-username
-/packages/rewards-service/ @your-github-username
-/packages/transfers-service/ @your-github-username
-/client/ @your-github-username
+/packages/skeleton/ @desoleary
+/packages/gateway/ @desoleary
+/packages/accounts-service/ @desoleary
+/packages/auth-service/ @desoleary
+/packages/rewards-service/ @desoleary
+/packages/transfers-service/ @desoleary
+/client/ @desoleary

--- a/packages/skeleton/src/configLoader.ts
+++ b/packages/skeleton/src/configLoader.ts
@@ -1,0 +1,8 @@
+export function loadConfig<T extends Record<string, any>>(defaults: T): T {
+  return Object.fromEntries(
+    Object.entries(defaults).map(([key, value]) => [
+      key,
+      process.env[key] ?? value,
+    ]),
+  ) as T;
+}

--- a/packages/skeleton/src/index.ts
+++ b/packages/skeleton/src/index.ts
@@ -1,1 +1,2 @@
 export * from './observabilityHooks';
+export * from './configLoader';


### PR DESCRIPTION
## Summary
- update CODEOWNERS to use a real GitHub handle
- expose new `loadConfig` helper in skeleton package

## Testing
- `pnpm -r build` *(fails: vite not found)*
- `pnpm -r test` *(fails: vitest not found)*
- `pnpm lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684399fdae388331b90766ca6c19b8a6