### PR TITLE
Implement schema-driven UI and seed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,34 @@ pnpm build
 ```
 
 Run services individually from their package directories using `pnpm dev`.
+
+## Dynamic UI Components
+
+Example usage for `DynamicForm`:
+
+```tsx
+import { DynamicForm } from './src/components/DynamicForm';
+import { userFormSchema } from './src/schemas/userFormSchema';
+
+<DynamicForm schema={userFormSchema} onSubmit={console.log} />
+```
+
+Example usage for `DynamicTable`:
+
+```tsx
+import { DynamicTable } from './src/components/DynamicTable';
+import { userTableColumns } from './src/schemas/userTableSchema';
+
+<DynamicTable columns={userTableColumns} data={[{ id: '1', email: 'a@b.com', tier: 'gold' }]} />
+```
+
+Example usage for `DynamicChart`:
+
+```tsx
+import { DynamicChart } from './src/components/DynamicChart';
+import { sampleChartConfig } from './src/schemas/chartConfig';
+
+<DynamicChart config={sampleChartConfig} />
+```
+
+The Dashboard page composes these components via `DynamicLayout`.

--- a/client/index.html
+++ b/client/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Neo Rewards Demo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/client/package.json
+++ b/client/package.json
@@ -5,16 +5,26 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@apollo/client": "^3.8.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0",
+    "react-hook-form": "^7.50.0",
+    "zod": "^3.22.4",
+    "@hookform/resolvers": "^3.3.3",
+    "chart.js": "^4.4.1"
   },
   "devDependencies": {
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.4.3",
     "@vitejs/plugin-react": "^4.0.0",
     "typescript": "^5.2.2",
-    "vite": "^4.0.0"
+    "vite": "^4.0.0",
+    "vitest": "^1.6.1",
+    "jsdom": "^24.0.0"
   }
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,22 +1,28 @@
-import { gql, useQuery } from '@apollo/client';
 import React from 'react';
-
-const GET_USER_PROFILE = gql`
-  query GetUserProfile($id: ID!) {
-    getUserProfile(id: $id) {
-      id
-      email
-      tier
-    }
-  }
-`;
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { ApolloProvider } from '@apollo/client';
+import { client } from './hooks/apolloClient';
+import { AppShell } from './components/AppShell';
+import { DashboardPage } from './pages/DashboardPage';
+import { UsersPage } from './pages/UsersPage';
+import { AccountsPage } from './pages/AccountsPage';
+import { RewardsPage } from './pages/RewardsPage';
+import { TransfersPage } from './pages/TransfersPage';
 
 export default function App() {
-  const { data } = useQuery(GET_USER_PROFILE, { variables: { id: '1' } });
   return (
-    <div>
-      <h1>Neo Rewards Demo</h1>
-      {data && <pre>{JSON.stringify(data, null, 2)}</pre>}
-    </div>
+    <ApolloProvider client={client}>
+      <BrowserRouter>
+        <AppShell>
+          <Routes>
+            <Route path="/" element={<DashboardPage />} />
+            <Route path="/users" element={<UsersPage />} />
+            <Route path="/accounts" element={<AccountsPage />} />
+            <Route path="/rewards" element={<RewardsPage />} />
+            <Route path="/transfers" element={<TransfersPage />} />
+          </Routes>
+        </AppShell>
+      </BrowserRouter>
+    </ApolloProvider>
   );
 }

--- a/client/src/components/AppShell.tsx
+++ b/client/src/components/AppShell.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { NavBar } from './NavBar';
+
+export function AppShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <NavBar />
+      <main className="flex-1 p-4">{children}</main>
+    </div>
+  );
+}

--- a/client/src/components/DynamicChart.test.tsx
+++ b/client/src/components/DynamicChart.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { DynamicChart } from './DynamicChart';
+import { sampleChartConfig } from '../schemas/chartConfig';
+
+describe('DynamicChart', () => {
+  it('renders canvas element', () => {
+    render(<DynamicChart config={sampleChartConfig} />);
+    expect(screen.getByLabelText('chart')).toBeInTheDocument();
+  });
+});

--- a/client/src/components/DynamicChart.tsx
+++ b/client/src/components/DynamicChart.tsx
@@ -1,0 +1,19 @@
+import React, { useEffect, useRef } from 'react';
+import { Chart, ChartConfiguration } from 'chart.js/auto';
+
+export function DynamicChart({ config }: { config: ChartConfiguration }) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || typeof canvas.getContext !== 'function') return;
+    try {
+      const chart = new Chart(canvas, config);
+      return () => chart.destroy();
+    } catch {
+      // ignore in non-browser environments
+    }
+  }, [config]);
+
+  return <canvas ref={canvasRef} aria-label="chart" />;
+}

--- a/client/src/components/DynamicForm.test.tsx
+++ b/client/src/components/DynamicForm.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { DynamicForm } from './DynamicForm';
+import { userFormSchema } from '../schemas/userFormSchema';
+
+describe('DynamicForm', () => {
+  it('submits form values', async () => {
+    const handleSubmit = vi.fn();
+    render(<DynamicForm schema={userFormSchema} onSubmit={handleSubmit} />);
+    fireEvent.input(screen.getByLabelText('Email'), { target: { value: 'a@b.com' } });
+    fireEvent.input(screen.getByLabelText('Tier'), { target: { value: 'gold' } });
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+    await waitFor(() => expect(handleSubmit).toHaveBeenCalled());
+    expect(handleSubmit.mock.calls[0][0]).toEqual({ email: 'a@b.com', tier: 'gold' });
+  });
+});

--- a/client/src/components/DynamicForm.tsx
+++ b/client/src/components/DynamicForm.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z, ZodSchema } from 'zod';
+
+export interface FieldConfig {
+  name: string;
+  label: string;
+  type: string;
+}
+
+export interface FormSchema<T extends z.ZodTypeAny> {
+  fields: FieldConfig[];
+  validation: T;
+}
+
+export function DynamicForm<T extends z.ZodTypeAny>({
+  schema,
+  onSubmit,
+}: {
+  schema: FormSchema<T>;
+  onSubmit: (values: z.infer<T>) => void;
+}) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<z.infer<T>>({ resolver: zodResolver(schema.validation) });
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+      {schema.fields.map((field) => (
+        <div key={field.name} className="flex flex-col">
+          <label htmlFor={field.name}>{field.label}</label>
+          <input
+            id={field.name}
+            type={field.type}
+            className="border p-1"
+            {...register(field.name as any)}
+          />
+          {errors[field.name as keyof typeof errors] && (
+            <span role="alert" className="text-red-500 text-sm">
+              {(errors as any)[field.name]?.message as string}
+            </span>
+          )}
+        </div>
+      ))}
+      <button type="submit" className="bg-blue-500 text-white px-4 py-1">
+        Submit
+      </button>
+    </form>
+  );
+}

--- a/client/src/components/DynamicLayout.tsx
+++ b/client/src/components/DynamicLayout.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export function DynamicLayout({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">{title}</h1>
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/client/src/components/DynamicTable.test.tsx
+++ b/client/src/components/DynamicTable.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { DynamicTable } from './DynamicTable';
+import { userTableColumns, UserRow } from '../schemas/userTableSchema';
+
+describe('DynamicTable', () => {
+  it('renders table rows', () => {
+    const rows: UserRow[] = [
+      { id: '1', email: 'a@b.com', tier: 'gold' },
+      { id: '2', email: 'b@c.com', tier: 'silver' },
+    ];
+    render(<DynamicTable columns={userTableColumns} data={rows} />);
+    expect(screen.getByText('a@b.com')).toBeInTheDocument();
+    expect(screen.getByText('b@c.com')).toBeInTheDocument();
+  });
+});

--- a/client/src/components/DynamicTable.tsx
+++ b/client/src/components/DynamicTable.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+export interface ColumnConfig<T> {
+  key: keyof T;
+  header: string;
+}
+
+export function DynamicTable<T extends Record<string, any>>({
+  columns,
+  data,
+}: {
+  columns: ColumnConfig<T>[];
+  data: T[];
+}) {
+  return (
+    <table className="min-w-full border">
+      <thead>
+        <tr>
+          {columns.map((col) => (
+            <th key={String(col.key)} className="border px-2 py-1 text-left">
+              {col.header}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((row, i) => (
+          <tr key={i} className="border-t">
+            {columns.map((col) => (
+              <td key={String(col.key)} className="px-2 py-1">
+                {String(row[col.key])}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/client/src/components/NavBar.tsx
+++ b/client/src/components/NavBar.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export function NavBar() {
+  return (
+    <nav className="bg-gray-800 text-white p-2 flex space-x-4">
+      <Link to="/" className="hover:underline">
+        Dashboard
+      </Link>
+      <Link to="/users" className="hover:underline">
+        Users
+      </Link>
+      <Link to="/accounts" className="hover:underline">
+        Accounts
+      </Link>
+      <Link to="/rewards" className="hover:underline">
+        Rewards
+      </Link>
+      <Link to="/transfers" className="hover:underline">
+        Transfers
+      </Link>
+    </nav>
+  );
+}

--- a/client/src/hooks/apolloClient.ts
+++ b/client/src/hooks/apolloClient.ts
@@ -1,0 +1,6 @@
+import { ApolloClient, InMemoryCache } from '@apollo/client';
+
+export const client = new ApolloClient({
+  uri: 'http://localhost:4000/graphql',
+  cache: new InMemoryCache(),
+});

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,17 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { ApolloClient, InMemoryCache, ApolloProvider } from '@apollo/client';
 import App from './App';
-
-const client = new ApolloClient({
-  uri: 'http://localhost:4000/graphql',
-  cache: new InMemoryCache(),
-});
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <ApolloProvider client={client}>
-      <App />
-    </ApolloProvider>
+    <App />
   </React.StrictMode>
 );

--- a/client/src/pages/AccountsPage.tsx
+++ b/client/src/pages/AccountsPage.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { DynamicLayout } from '../components/DynamicLayout';
+
+export function AccountsPage() {
+  return <DynamicLayout title="Accounts">Accounts Page</DynamicLayout>;
+}

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { DynamicChart } from '../components/DynamicChart';
+import { sampleChartConfig } from '../schemas/chartConfig';
+import { DynamicLayout } from '../components/DynamicLayout';
+
+export function DashboardPage() {
+  return (
+    <DynamicLayout title="Dashboard">
+      <DynamicChart config={sampleChartConfig} />
+    </DynamicLayout>
+  );
+}

--- a/client/src/pages/RewardsPage.tsx
+++ b/client/src/pages/RewardsPage.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { DynamicLayout } from '../components/DynamicLayout';
+
+export function RewardsPage() {
+  return <DynamicLayout title="Rewards">Rewards Page</DynamicLayout>;
+}

--- a/client/src/pages/TransfersPage.tsx
+++ b/client/src/pages/TransfersPage.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { DynamicLayout } from '../components/DynamicLayout';
+
+export function TransfersPage() {
+  return <DynamicLayout title="Transfers">Transfers Page</DynamicLayout>;
+}

--- a/client/src/pages/UsersPage.tsx
+++ b/client/src/pages/UsersPage.tsx
@@ -1,0 +1,23 @@
+import React, { useState } from 'react';
+import { DynamicForm } from '../components/DynamicForm';
+import { userFormSchema } from '../schemas/userFormSchema';
+import { DynamicTable } from '../components/DynamicTable';
+import { userTableColumns, UserRow } from '../schemas/userTableSchema';
+import { DynamicLayout } from '../components/DynamicLayout';
+
+export function UsersPage() {
+  const [rows, setRows] = useState<UserRow[]>([]);
+  return (
+    <DynamicLayout title="Users">
+      <DynamicForm
+        schema={userFormSchema}
+        onSubmit={(values) =>
+          setRows((r) => [...r, { id: (r.length + 1).toString(), ...values }])
+        }
+      />
+      <div className="mt-4">
+        <DynamicTable columns={userTableColumns} data={rows} />
+      </div>
+    </DynamicLayout>
+  );
+}

--- a/client/src/schemas/chartConfig.ts
+++ b/client/src/schemas/chartConfig.ts
@@ -1,0 +1,15 @@
+import { ChartConfiguration } from 'chart.js/auto';
+
+export const sampleChartConfig: ChartConfiguration = {
+  type: 'bar',
+  data: {
+    labels: ['A', 'B', 'C'],
+    datasets: [
+      {
+        label: 'Demo',
+        data: [3, 7, 4],
+        backgroundColor: 'rgba(99, 102, 241, 0.5)',
+      },
+    ],
+  },
+};

--- a/client/src/schemas/userFormSchema.ts
+++ b/client/src/schemas/userFormSchema.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+import { FormSchema } from '../components/DynamicForm';
+
+export const userSchema = z.object({
+  email: z.string().email(),
+  tier: z.string(),
+});
+
+export const userFormSchema: FormSchema<typeof userSchema> = {
+  fields: [
+    { name: 'email', label: 'Email', type: 'email' },
+    { name: 'tier', label: 'Tier', type: 'text' },
+  ],
+  validation: userSchema,
+};

--- a/client/src/schemas/userTableSchema.ts
+++ b/client/src/schemas/userTableSchema.ts
@@ -1,0 +1,13 @@
+import { ColumnConfig } from '../components/DynamicTable';
+
+export interface UserRow {
+  id: string;
+  email: string;
+  tier: string;
+}
+
+export const userTableColumns: ColumnConfig<UserRow>[] = [
+  { key: 'id', header: 'ID' },
+  { key: 'email', header: 'Email' },
+  { key: 'tier', header: 'Tier' },
+];

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": ["vitest/globals"]
   },
-  "include": ["src"]
+  "include": ["src", "vitest.setup.ts"]
 }

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -3,4 +3,9 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './vitest.setup.ts'
+  }
 });

--- a/client/vitest.setup.ts
+++ b/client/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "start:services": "pnpm --parallel --filter \"@neo-rewards/*-service\" dev",
     "start:gateway": "pnpm --filter @neo-rewards/gateway dev",
     "start:client": "pnpm --filter client dev",
-    "start:all": "concurrently \"pnpm start:services\" \"pnpm start:gateway\" \"pnpm start:client\""
+    "start:all": "concurrently \"pnpm start:services\" \"pnpm start:gateway\" \"pnpm start:client\"",
+    "seed": "pnpm --filter \"@neo-rewards/*-service\" seed"
   },
   "workspaces": [
     "packages/*",

--- a/packages/accounts-service/package.json
+++ b/packages/accounts-service/package.json
@@ -8,7 +8,8 @@
     "build": "tsc",
     "dev": "ts-node src/index.ts",
     "start": "node dist/index.js",
-    "test": "vitest"
+    "test": "vitest",
+    "seed": "ts-node src/seed.ts"
   },
   "dependencies": {
     "@apollo/server": "^4.7.5",
@@ -20,6 +21,7 @@
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2",
     "vitest": "^1.0.0",
-    "mongodb-memory-server": "^8.11.0"
+    "mongodb-memory-server": "^8.11.0",
+    "fishery": "^2.3.1"
   }
 }

--- a/packages/accounts-service/src/data.ts
+++ b/packages/accounts-service/src/data.ts
@@ -1,0 +1,16 @@
+export interface Account {
+  id: string;
+  userId: string;
+  type: string;
+  balance: number;
+}
+
+export interface Transaction {
+  id: string;
+  accountId: string;
+  amount: number;
+  date: string;
+}
+
+export const accounts: Account[] = [];
+export const transactions: Transaction[] = [];

--- a/packages/accounts-service/src/factories/accountFactory.ts
+++ b/packages/accounts-service/src/factories/accountFactory.ts
@@ -1,0 +1,16 @@
+import { Factory } from 'fishery';
+import { Account, Transaction, accounts, transactions } from '../data';
+
+export const accountFactory = Factory.define<Account>(({ sequence }) => ({
+  id: sequence.toString(),
+  userId: (sequence % 10).toString(),
+  type: ['chequing', 'savings'][sequence % 2],
+  balance: 1000 * (sequence % 5),
+}));
+
+export const transactionFactory = Factory.define<Transaction>(({ sequence }) => ({
+  id: sequence.toString(),
+  accountId: (sequence % 10).toString(),
+  amount: 50,
+  date: new Date().toISOString(),
+}));

--- a/packages/accounts-service/src/index.ts
+++ b/packages/accounts-service/src/index.ts
@@ -5,36 +5,44 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import gql from 'graphql-tag';
 import { createObservabilityPlugins } from '@neo-rewards/skeleton';
+import { accounts, transactions } from './data';
+import { seed } from './seed';
 
 const typeDefs = gql`
   ${readFileSync(join(__dirname, 'graphql/schema/account.graphql'), 'utf8')}
 `;
 
 const resolvers = {
-  // Add your resolvers here
+  Query: {
+    getUserAccounts: (_: any, { userId }: { userId: string }) =>
+      accounts.filter((a) => a.userId === userId),
+    getTransactionHistory: (_: any, { accountId }: { accountId: string }) =>
+      transactions.filter((t) => t.accountId === accountId),
+  },
 };
 
 async function start() {
+  await seed();
   const schema = buildSubgraphSchema([{ typeDefs, resolvers }]);
-  
+
   const server = new ApolloServer({
     schema,
     plugins: [createObservabilityPlugins()],
   });
 
-  const { url } = await startStandaloneServer(server, { 
-    listen: { 
+  const { url } = await startStandaloneServer(server, {
+    listen: {
       port: 4002,
-      host: '0.0.0.0' 
-    } 
+      host: '0.0.0.0',
+    },
   });
-  
+
   const schemaContent = readFileSync(join(__dirname, 'graphql/schema/account.graphql'), 'utf8');
   console.log(`🚀 accounts-service ready at ${url}`);
   console.log(`📄 Schema loaded with ${schemaContent.split('\n').length} lines`);
 }
 
-start().catch(error => {
+start().catch((error) => {
   console.error('Failed to start accounts-service:', error);
   process.exit(1);
 });

--- a/packages/accounts-service/src/seed.ts
+++ b/packages/accounts-service/src/seed.ts
@@ -1,0 +1,15 @@
+import { accounts, transactions } from './data';
+import { accountFactory, transactionFactory } from './factories/accountFactory';
+
+export async function seed() {
+  accounts.length = 0;
+  transactions.length = 0;
+  for (let i = 0; i < 100; i++) {
+    accounts.push(accountFactory.build());
+    transactions.push(transactionFactory.build());
+  }
+}
+
+if (require.main === module) {
+  seed().then(() => console.log('seeded accounts:', accounts.length));
+}

--- a/packages/auth-service/package.json
+++ b/packages/auth-service/package.json
@@ -8,7 +8,8 @@
     "build": "tsc",
     "dev": "ts-node src/index.ts",
     "start": "node dist/index.js",
-    "test": "vitest"
+    "test": "vitest",
+    "seed": "ts-node src/seed.ts"
   },
   "dependencies": {
     "@apollo/server": "^4.7.5",
@@ -20,6 +21,7 @@
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2",
     "vitest": "^1.0.0",
-    "mongodb-memory-server": "^8.11.0"
+    "mongodb-memory-server": "^8.11.0",
+    "fishery": "^2.3.1"
   }
 }

--- a/packages/auth-service/src/data.ts
+++ b/packages/auth-service/src/data.ts
@@ -1,0 +1,8 @@
+export interface User {
+  id: string;
+  email: string;
+  password: string;
+  tier: string;
+}
+
+export const users: User[] = [];

--- a/packages/auth-service/src/factories/userFactory.ts
+++ b/packages/auth-service/src/factories/userFactory.ts
@@ -1,0 +1,9 @@
+import { Factory } from 'fishery';
+import { User } from '../data';
+
+export const userFactory = Factory.define<User>(({ sequence }) => ({
+  id: sequence.toString(),
+  email: `user${sequence}@example.com`,
+  password: 'password',
+  tier: ['basic', 'gold', 'platinum'][sequence % 3],
+}));

--- a/packages/auth-service/src/index.ts
+++ b/packages/auth-service/src/index.ts
@@ -5,36 +5,50 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import gql from 'graphql-tag';
 import { createObservabilityPlugins } from '@neo-rewards/skeleton';
+import { users } from './data';
+import { seed } from './seed';
 
 const typeDefs = gql`
   ${readFileSync(join(__dirname, 'graphql/schema/user.graphql'), 'utf8')}
 `;
 
 const resolvers = {
-  // Add your resolvers here
+  Query: {
+    getUserProfile: (_: any, { id }: { id: string }) => users.find((u) => u.id === id),
+    login: (_: any, { email, password }: { email: string; password: string }) =>
+      users.find((u) => u.email === email && u.password === password),
+  },
+  Mutation: {
+    updateUserTier: (_: any, { id, tier }: { id: string; tier: string }) => {
+      const user = users.find((u) => u.id === id);
+      if (user) user.tier = tier;
+      return user;
+    },
+  },
 };
 
 async function start() {
+  await seed();
   const schema = buildSubgraphSchema([{ typeDefs, resolvers }]);
-  
+
   const server = new ApolloServer({
     schema,
     plugins: [createObservabilityPlugins()],
   });
 
-  const { url } = await startStandaloneServer(server, { 
-    listen: { 
+  const { url } = await startStandaloneServer(server, {
+    listen: {
       port: 4001,
-      host: '0.0.0.0' 
-    } 
+      host: '0.0.0.0',
+    },
   });
-  
+
   const schemaContent = readFileSync(join(__dirname, 'graphql/schema/user.graphql'), 'utf8');
   console.log(`🚀 auth-service ready at ${url}`);
   console.log(`📄 Schema loaded with ${schemaContent.split('\n').length} lines`);
 }
 
-start().catch(error => {
+start().catch((error) => {
   console.error('Failed to start auth-service:', error);
   process.exit(1);
 });

--- a/packages/auth-service/src/seed.ts
+++ b/packages/auth-service/src/seed.ts
@@ -1,0 +1,13 @@
+import { users } from './data';
+import { userFactory } from './factories/userFactory';
+
+export async function seed() {
+  users.length = 0;
+  for (let i = 0; i < 100; i++) {
+    users.push(userFactory.build());
+  }
+}
+
+if (require.main === module) {
+  seed().then(() => console.log('seeded users:', users.length));
+}

--- a/packages/rewards-service/package.json
+++ b/packages/rewards-service/package.json
@@ -8,7 +8,8 @@
     "build": "tsc",
     "dev": "ts-node src/index.ts",
     "start": "node dist/index.js",
-    "test": "vitest"
+    "test": "vitest",
+    "seed": "ts-node src/seed.ts"
   },
   "dependencies": {
     "@apollo/server": "^4.7.5",
@@ -20,6 +21,7 @@
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2",
     "vitest": "^1.0.0",
-    "mongodb-memory-server": "^8.11.0"
+    "mongodb-memory-server": "^8.11.0",
+    "fishery": "^2.3.1"
   }
 }

--- a/packages/rewards-service/src/data.ts
+++ b/packages/rewards-service/src/data.ts
@@ -1,0 +1,7 @@
+export interface Reward {
+  id: string;
+  description: string;
+  points: number;
+}
+
+export const rewards: Reward[] = [];

--- a/packages/rewards-service/src/factories/rewardFactory.ts
+++ b/packages/rewards-service/src/factories/rewardFactory.ts
@@ -1,0 +1,8 @@
+import { Factory } from 'fishery';
+import { Reward } from '../data';
+
+export const rewardFactory = Factory.define<Reward>(({ sequence }) => ({
+  id: sequence.toString(),
+  description: `Reward ${sequence}`,
+  points: (sequence + 1) * 10,
+}));

--- a/packages/rewards-service/src/index.ts
+++ b/packages/rewards-service/src/index.ts
@@ -5,36 +5,44 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import gql from 'graphql-tag';
 import { createObservabilityPlugins } from '@neo-rewards/skeleton';
+import { rewards } from './data';
+import { seed } from './seed';
 
 const typeDefs = gql`
   ${readFileSync(join(__dirname, 'graphql/schema/reward.graphql'), 'utf8')}
 `;
 
 const resolvers = {
-  // Add your resolvers here
+  Query: {
+    getRewards: () => rewards,
+  },
+  Mutation: {
+    redeemReward: (_: any, { id }: { id: string }) => rewards.find((r) => r.id === id),
+  },
 };
 
 async function start() {
+  await seed();
   const schema = buildSubgraphSchema([{ typeDefs, resolvers }]);
-  
+
   const server = new ApolloServer({
     schema,
     plugins: [createObservabilityPlugins()],
   });
 
-  const { url } = await startStandaloneServer(server, { 
-    listen: { 
+  const { url } = await startStandaloneServer(server, {
+    listen: {
       port: 4003,
-      host: '0.0.0.0' 
-    } 
+      host: '0.0.0.0',
+    },
   });
-  
+
   const schemaContent = readFileSync(join(__dirname, 'graphql/schema/reward.graphql'), 'utf8');
   console.log(`🚀 rewards-service ready at ${url}`);
   console.log(`📄 Schema loaded with ${schemaContent.split('\n').length} lines`);
 }
 
-start().catch(error => {
+start().catch((error) => {
   console.error('Failed to start rewards-service:', error);
   process.exit(1);
 });

--- a/packages/rewards-service/src/seed.ts
+++ b/packages/rewards-service/src/seed.ts
@@ -1,0 +1,13 @@
+import { rewards } from './data';
+import { rewardFactory } from './factories/rewardFactory';
+
+export async function seed() {
+  rewards.length = 0;
+  for (let i = 0; i < 100; i++) {
+    rewards.push(rewardFactory.build());
+  }
+}
+
+if (require.main === module) {
+  seed().then(() => console.log('seeded rewards:', rewards.length));
+}

--- a/packages/transfers-service/package.json
+++ b/packages/transfers-service/package.json
@@ -8,7 +8,8 @@
     "build": "tsc",
     "dev": "ts-node src/index.ts",
     "start": "node dist/index.js",
-    "test": "vitest"
+    "test": "vitest",
+    "seed": "ts-node src/seed.ts"
   },
   "dependencies": {
     "@apollo/server": "^4.7.5",
@@ -20,6 +21,7 @@
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2",
     "vitest": "^1.0.0",
-    "mongodb-memory-server": "^8.11.0"
+    "mongodb-memory-server": "^8.11.0",
+    "fishery": "^2.3.1"
   }
 }

--- a/packages/transfers-service/src/data.ts
+++ b/packages/transfers-service/src/data.ts
@@ -1,0 +1,6 @@
+export interface TransferResult {
+  id: string;
+  status: string;
+}
+
+export const transfers: TransferResult[] = [];

--- a/packages/transfers-service/src/factories/transferFactory.ts
+++ b/packages/transfers-service/src/factories/transferFactory.ts
@@ -1,0 +1,7 @@
+import { Factory } from 'fishery';
+import { TransferResult } from '../data';
+
+export const transferFactory = Factory.define<TransferResult>(({ sequence }) => ({
+  id: sequence.toString(),
+  status: 'SUCCESS',
+}));

--- a/packages/transfers-service/src/seed.ts
+++ b/packages/transfers-service/src/seed.ts
@@ -1,0 +1,13 @@
+import { transfers } from './data';
+import { transferFactory } from './factories/transferFactory';
+
+export async function seed() {
+  transfers.length = 0;
+  for (let i = 0; i < 100; i++) {
+    transfers.push(transferFactory.build());
+  }
+}
+
+if (require.main === module) {
+  seed().then(() => console.log('seeded transfers:', transfers.length));
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,23 +23,50 @@ importers:
     dependencies:
       '@apollo/client':
         specifier: ^3.8.0
-        version: 3.13.8(graphql-ws@6.0.5(graphql@16.11.0)(ws@8.18.2))(graphql@16.11.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.13.8(@types/react@18.3.23)(graphql-ws@6.0.5(graphql@16.11.0)(ws@8.18.2))(graphql@16.11.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@hookform/resolvers':
+        specifier: ^3.3.3
+        version: 3.10.0(react-hook-form@7.57.0(react@18.3.1))
+      chart.js:
+        specifier: ^4.4.1
+        version: 4.4.9
       react:
         specifier: ^18.2.0
         version: 18.3.1
       react-dom:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
+      react-hook-form:
+        specifier: ^7.50.0
+        version: 7.57.0(react@18.3.1)
+      react-router-dom:
+        specifier: ^6.23.0
+        version: 6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      zod:
+        specifier: ^3.22.4
+        version: 3.25.56
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.4.3
+        version: 6.6.3
+      '@testing-library/react':
+        specifier: ^14.1.2
+        version: 14.3.1(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@vitejs/plugin-react':
         specifier: ^4.0.0
         version: 4.5.1(vite@4.5.14(@types/node@22.15.30))
+      jsdom:
+        specifier: ^24.0.0
+        version: 24.1.3
       typescript:
         specifier: ^5.2.2
         version: 5.8.3
       vite:
         specifier: ^4.0.0
         version: 4.5.14(@types/node@22.15.30)
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@22.15.30)(jsdom@24.1.3)
 
   packages/accounts-service:
     dependencies:
@@ -56,6 +83,9 @@ importers:
         specifier: ^6.0.0
         version: 6.17.0(@aws-sdk/credential-providers@3.826.0)(socks@2.8.4)
     devDependencies:
+      fishery:
+        specifier: ^2.3.1
+        version: 2.3.1
       mongodb-memory-server:
         specifier: ^8.11.0
         version: 8.16.1
@@ -67,7 +97,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@22.15.30)
+        version: 1.6.1(@types/node@22.15.30)(jsdom@24.1.3)
 
   packages/auth-service:
     dependencies:
@@ -84,6 +114,9 @@ importers:
         specifier: ^6.0.0
         version: 6.17.0(@aws-sdk/credential-providers@3.826.0)(socks@2.8.4)
     devDependencies:
+      fishery:
+        specifier: ^2.3.1
+        version: 2.3.1
       mongodb-memory-server:
         specifier: ^8.11.0
         version: 8.16.1
@@ -95,7 +128,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@22.15.30)
+        version: 1.6.1(@types/node@22.15.30)(jsdom@24.1.3)
 
   packages/gateway:
     dependencies:
@@ -120,7 +153,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@22.15.30)
+        version: 1.6.1(@types/node@22.15.30)(jsdom@24.1.3)
 
   packages/rewards-service:
     dependencies:
@@ -137,6 +170,9 @@ importers:
         specifier: ^6.0.0
         version: 6.17.0(@aws-sdk/credential-providers@3.826.0)(socks@2.8.4)
     devDependencies:
+      fishery:
+        specifier: ^2.3.1
+        version: 2.3.1
       mongodb-memory-server:
         specifier: ^8.11.0
         version: 8.16.1
@@ -148,7 +184,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@22.15.30)
+        version: 1.6.1(@types/node@22.15.30)(jsdom@24.1.3)
 
   packages/skeleton:
     devDependencies:
@@ -171,6 +207,9 @@ importers:
         specifier: ^6.0.0
         version: 6.17.0(@aws-sdk/credential-providers@3.826.0)(socks@2.8.4)
     devDependencies:
+      fishery:
+        specifier: ^2.3.1
+        version: 2.3.1
       mongodb-memory-server:
         specifier: ^8.11.0
         version: 8.16.1
@@ -182,9 +221,12 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@22.15.30)
+        version: 1.6.1(@types/node@22.15.30)(jsdom@24.1.3)
 
 packages:
+
+  '@adobe/css-tools@4.4.3':
+    resolution: {integrity: sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -326,6 +368,9 @@ packages:
   '@apollo/utils.withrequired@2.0.1':
     resolution: {integrity: sha512-YBDiuAX9i1lLc6GeTy1m7DGLFn/gMnvXqlalOIMjM7DeOgIacEjjfwPqb0M1CQ2v11HhR15d1NmxJoRCfrNqcA==}
     engines: {node: '>=14'}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@aws-crypto/sha256-browser@5.2.0':
     resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
@@ -511,6 +556,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/runtime@7.27.6':
+    resolution: {integrity: sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.27.2':
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
     engines: {node: '>=6.9.0'}
@@ -526,6 +575,34 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@csstools/color-helpers@5.0.2':
+    resolution: {integrity: sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.0.10':
+    resolution: {integrity: sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -817,6 +894,11 @@ packages:
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
+  '@hookform/resolvers@3.10.0':
+    resolution: {integrity: sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==}
+    peerDependencies:
+      react-hook-form: ^7.0.0
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -848,6 +930,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@kurkle/color@0.3.4':
+    resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
 
   '@mongodb-js/saslprep@1.2.2':
     resolution: {integrity: sha512-EB0O3SCSNRUFk66iRCpI+cXzIjdswfCs7F6nOC3RAGJ7xr5YhaicvsRwJ9eyzYvYRlCSDUO/c7g4yNulxKC1WA==}
@@ -893,6 +978,10 @@ packages:
 
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@remix-run/router@1.23.0':
+    resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
+    engines: {node: '>=14.0.0'}
 
   '@rolldown/pluginutils@1.0.0-beta.9':
     resolution: {integrity: sha512-e9MeMtVWo186sgvFFJOPGy7/d2j2mZhLJIdVW0C/xDluuOvymEATqz6zKsP0ZmXGzQtqlyjz5sC1sYQUoJG98w==}
@@ -1168,6 +1257,21 @@ packages:
     resolution: {integrity: sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==}
     engines: {node: '>=18.0.0'}
 
+  '@testing-library/dom@9.3.4':
+    resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
+    engines: {node: '>=14'}
+
+  '@testing-library/jest-dom@6.6.3':
+    resolution: {integrity: sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@14.3.1':
+    resolution: {integrity: sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
@@ -1183,6 +1287,9 @@ packages:
 
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1229,11 +1336,22 @@ packages:
   '@types/node@22.15.30':
     resolution: {integrity: sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==}
 
+  '@types/prop-types@15.7.14':
+    resolution: {integrity: sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==}
+
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
 
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
+  '@types/react@18.3.23':
+    resolution: {integrity: sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==}
 
   '@types/send@0.17.5':
     resolution: {integrity: sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==}
@@ -1307,6 +1425,10 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
+  agent-base@7.1.3:
+    resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
+    engines: {node: '>= 14'}
+
   agentkeepalive@4.6.0:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
@@ -1337,6 +1459,13 @@ packages:
 
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+
+  aria-query@5.1.3:
+    resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
@@ -1434,9 +1563,17 @@ packages:
     resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
     engines: {node: '>=4'}
 
+  chalk@3.0.0:
+    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
+    engines: {node: '>=8'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  chart.js@4.4.9:
+    resolution: {integrity: sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==}
+    engines: {pnpm: '>=8'}
 
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
@@ -1504,6 +1641,20 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssstyle@4.3.1:
+    resolution: {integrity: sha512-ZgW+Jgdd7i52AaLYCriF8Mxqft0gD/R9i9wi6RWBhs1pqdPEzPjym7rvRKi397WmQFf3SlyUsszhw+VVCbx79Q==}
+    engines: {node: '>=18'}
+
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -1520,6 +1671,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.5.0:
+    resolution: {integrity: sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==}
 
   deep-eql@4.1.4:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
@@ -1557,6 +1711,12 @@ packages:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -1589,6 +1749,10 @@ packages:
 
   end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
+
+  entities@6.0.0:
+    resolution: {integrity: sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==}
+    engines: {node: '>=0.12'}
 
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
@@ -1662,6 +1826,9 @@ packages:
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
+
+  fishery@2.3.1:
+    resolution: {integrity: sha512-eKgpAfx88/dFnLUGhJmq9eslN6nsHUcCR13Th1z6tLZixUtKjW/33MqKuzxGtYmhzUh2yLYZxq4jHxIQd3F04A==}
 
   follow-redirects@1.15.9:
     resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
@@ -1808,6 +1975,10 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
@@ -1819,9 +1990,17 @@ packages:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
     engines: {node: '>= 6'}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
@@ -1903,6 +2082,9 @@ packages:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -1957,6 +2139,15 @@ packages:
   jsbn@1.1.0:
     resolution: {integrity: sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==}
 
+  jsdom@24.1.3:
+    resolution: {integrity: sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -1974,6 +2165,9 @@ packages:
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
+
+  lodash.mergewith@4.6.2:
+    resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
 
   lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
@@ -2004,6 +2198,10 @@ packages:
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -2061,6 +2259,10 @@ packages:
   mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
@@ -2197,6 +2399,9 @@ packages:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  nwsapi@2.2.20:
+    resolution: {integrity: sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -2254,6 +2459,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -2307,6 +2515,10 @@ packages:
     resolution: {integrity: sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==}
     engines: {node: ^10 || ^12 || >=14}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2322,6 +2534,9 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -2329,6 +2544,9 @@ packages:
   qs@6.13.0:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
     engines: {node: '>=0.6'}
+
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -2343,8 +2561,17 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-hook-form@7.57.0:
+    resolution: {integrity: sha512-RbEks3+cbvTP84l/VXGUZ+JMrKOS8ykQCRYdm5aYsxnDquL0vspsyNhGRO7pcH6hsZqWlPOjLye7rJqdtdAmlg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -2353,6 +2580,19 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-router-dom@6.30.1:
+    resolution: {integrity: sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  react-router@6.30.1:
+    resolution: {integrity: sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -2360,6 +2600,10 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
@@ -2380,6 +2624,9 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
@@ -2398,6 +2645,12 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
@@ -2410,6 +2663,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -2544,6 +2801,10 @@ packages:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-literal@2.1.1:
     resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
@@ -2561,6 +2822,9 @@ packages:
   symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
     engines: {node: '>=0.10'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
@@ -2584,6 +2848,10 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
@@ -2652,6 +2920,10 @@ packages:
     resolution: {integrity: sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -2661,6 +2933,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -2773,6 +3048,10 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -2780,9 +3059,17 @@ packages:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
 
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
 
   whatwg-url@11.0.0:
     resolution: {integrity: sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==}
@@ -2840,6 +3127,13 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -2875,7 +3169,12 @@ packages:
   zen-observable@0.8.15:
     resolution: {integrity: sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==}
 
+  zod@3.25.56:
+    resolution: {integrity: sha512-rd6eEF3BTNvQnR2e2wwolfTmUTnp70aUTqr0oaGbHifzC3BKJsoV+Gat8vxUMR1hwOKBs6El+qWehrHbCpW6SQ==}
+
 snapshots:
+
+  '@adobe/css-tools@4.4.3': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -2886,7 +3185,7 @@ snapshots:
     dependencies:
       graphql: 16.11.0
 
-  '@apollo/client@3.13.8(graphql-ws@6.0.5(graphql@16.11.0)(ws@8.18.2))(graphql@16.11.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@apollo/client@3.13.8(@types/react@18.3.23)(graphql-ws@6.0.5(graphql@16.11.0)(ws@8.18.2))(graphql@16.11.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.11.0)
       '@wry/caches': 1.0.1
@@ -2897,7 +3196,7 @@ snapshots:
       hoist-non-react-statics: 3.3.2
       optimism: 0.18.1
       prop-types: 15.8.1
-      rehackt: 0.1.0(react@18.3.1)
+      rehackt: 0.1.0(@types/react@18.3.23)(react@18.3.1)
       symbol-observable: 4.0.0
       ts-invariant: 0.10.3
       tslib: 2.8.1
@@ -3078,6 +3377,14 @@ snapshots:
       graphql: 16.11.0
 
   '@apollo/utils.withrequired@2.0.1': {}
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.0.10(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@aws-crypto/sha256-browser@5.2.0':
     dependencies:
@@ -3579,6 +3886,8 @@ snapshots:
       '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/runtime@7.27.6': {}
+
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -3605,6 +3914,26 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@csstools/color-helpers@5.0.2': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.0.10(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.0.2
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -3765,6 +4094,10 @@ snapshots:
     dependencies:
       graphql: 16.11.0
 
+  '@hookform/resolvers@3.10.0(react-hook-form@7.57.0(react@18.3.1))':
+    dependencies:
+      react-hook-form: 7.57.0(react@18.3.1)
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -3802,6 +4135,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@kurkle/color@0.3.4': {}
+
   '@mongodb-js/saslprep@1.2.2':
     dependencies:
       sparse-bitfield: 3.0.3
@@ -3837,6 +4172,8 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.0': {}
+
+  '@remix-run/router@1.23.0': {}
 
   '@rolldown/pluginutils@1.0.0-beta.9': {}
 
@@ -4213,6 +4550,37 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@testing-library/dom@9.3.4':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/runtime': 7.27.6
+      '@types/aria-query': 5.0.4
+      aria-query: 5.1.3
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.6.3':
+    dependencies:
+      '@adobe/css-tools': 4.4.3
+      aria-query: 5.3.2
+      chalk: 3.0.0
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      lodash: 4.17.21
+      redent: 3.0.0
+
+  '@testing-library/react@14.3.1(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.6
+      '@testing-library/dom': 9.3.4
+      '@types/react-dom': 18.3.7(@types/react@18.3.23)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+
   '@tootallnate/once@2.0.0': {}
 
   '@tsconfig/node10@1.0.11': {}
@@ -4222,6 +4590,8 @@ snapshots:
   '@tsconfig/node14@1.0.3': {}
 
   '@tsconfig/node16@1.0.4': {}
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -4286,9 +4656,20 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/prop-types@15.7.14': {}
+
   '@types/qs@6.14.0': {}
 
   '@types/range-parser@1.2.7': {}
+
+  '@types/react-dom@18.3.7(@types/react@18.3.23)':
+    dependencies:
+      '@types/react': 18.3.23
+
+  '@types/react@18.3.23':
+    dependencies:
+      '@types/prop-types': 15.7.14
+      csstype: 3.1.3
 
   '@types/send@0.17.5':
     dependencies:
@@ -4388,6 +4769,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  agent-base@7.1.3: {}
+
   agentkeepalive@4.6.0:
     dependencies:
       humanize-ms: 1.2.1
@@ -4410,6 +4793,12 @@ snapshots:
   ansi-styles@6.2.1: {}
 
   arg@4.1.3: {}
+
+  aria-query@5.1.3:
+    dependencies:
+      deep-equal: 2.2.3
+
+  aria-query@5.3.2: {}
 
   array-buffer-byte-length@1.0.2:
     dependencies:
@@ -4538,10 +4927,19 @@ snapshots:
       pathval: 1.1.1
       type-detect: 4.1.0
 
+  chalk@3.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  chart.js@4.4.9:
+    dependencies:
+      '@kurkle/color': 0.3.4
 
   check-error@1.0.3:
     dependencies:
@@ -4606,6 +5004,20 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css.escape@1.5.1: {}
+
+  cssstyle@4.3.1:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
+  csstype@3.1.3: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
@@ -4613,6 +5025,8 @@ snapshots:
   debug@4.4.1:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.5.0: {}
 
   deep-eql@4.1.4:
     dependencies:
@@ -4661,6 +5075,10 @@ snapshots:
 
   diff@4.0.2: {}
 
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -4689,6 +5107,8 @@ snapshots:
   end-of-stream@1.4.4:
     dependencies:
       once: 1.4.0
+
+  entities@6.0.0: {}
 
   err-code@2.0.3: {}
 
@@ -4860,6 +5280,10 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
+  fishery@2.3.1:
+    dependencies:
+      lodash.mergewith: 4.6.2
+
   follow-redirects@1.15.9(debug@4.4.1):
     optionalDependencies:
       debug: 4.4.1
@@ -4979,6 +5403,10 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   http-cache-semantics@4.2.0: {}
 
   http-errors@2.0.0:
@@ -4997,9 +5425,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.3
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.3
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
@@ -5017,7 +5459,6 @@ snapshots:
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
-    optional: true
 
   ieee754@1.2.1: {}
 
@@ -5078,6 +5519,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -5129,6 +5572,34 @@ snapshots:
 
   jsbn@1.1.0: {}
 
+  jsdom@24.1.3:
+    dependencies:
+      cssstyle: 4.3.1
+      data-urls: 5.0.0
+      decimal.js: 10.5.0
+      form-data: 4.0.3
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.20
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 4.1.4
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.18.2
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   jsesc@3.1.0: {}
 
   json5@2.2.3: {}
@@ -5141,6 +5612,8 @@ snapshots:
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
+
+  lodash.mergewith@4.6.2: {}
 
   lodash.sortby@4.7.0: {}
 
@@ -5165,6 +5638,8 @@ snapshots:
       yallist: 3.1.1
 
   lru-cache@7.18.3: {}
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.17:
     dependencies:
@@ -5219,6 +5694,8 @@ snapshots:
   mime@1.6.0: {}
 
   mimic-fn@4.0.0: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@9.0.5:
     dependencies:
@@ -5359,6 +5836,8 @@ snapshots:
     dependencies:
       path-key: 4.0.0
 
+  nwsapi@2.2.20: {}
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -5418,6 +5897,10 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.0
+
   parseurl@1.3.3: {}
 
   path-exists@4.0.0: {}
@@ -5461,6 +5944,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   pretty-format@29.7.0:
     dependencies:
       '@jest/schemas': 29.6.3
@@ -5483,11 +5972,17 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+
   punycode@2.3.1: {}
 
   qs@6.13.0:
     dependencies:
       side-channel: 1.1.0
+
+  querystringify@2.2.0: {}
 
   range-parser@1.2.1: {}
 
@@ -5504,11 +5999,29 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-hook-form@7.57.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 
   react-refresh@0.17.0: {}
+
+  react-router-dom@6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@remix-run/router': 1.23.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-router: 6.30.1(react@18.3.1)
+
+  react-router@6.30.1(react@18.3.1):
+    dependencies:
+      '@remix-run/router': 1.23.0
+      react: 18.3.1
 
   react@18.3.1:
     dependencies:
@@ -5520,6 +6033,11 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   regexp.prototype.flags@1.5.4:
     dependencies:
       call-bind: 1.0.8
@@ -5529,11 +6047,14 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
-  rehackt@0.1.0(react@18.3.1):
+  rehackt@0.1.0(@types/react@18.3.23)(react@18.3.1):
     optionalDependencies:
+      '@types/react': 18.3.23
       react: 18.3.1
 
   require-directory@2.1.1: {}
+
+  requires-port@1.0.0: {}
 
   retry@0.12.0: {}
 
@@ -5569,6 +6090,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.42.0
       fsevents: 2.3.3
 
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
   rxjs@7.8.2:
     dependencies:
       tslib: 2.8.1
@@ -5582,6 +6107,10 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.23.2:
     dependencies:
@@ -5745,6 +6274,10 @@ snapshots:
 
   strip-final-newline@3.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-literal@2.1.1:
     dependencies:
       js-tokens: 9.0.1
@@ -5761,6 +6294,8 @@ snapshots:
       has-flag: 4.0.0
 
   symbol-observable@4.0.0: {}
+
+  symbol-tree@3.2.4: {}
 
   tar-stream@2.2.0:
     dependencies:
@@ -5786,6 +6321,13 @@ snapshots:
   tinyspy@2.2.1: {}
 
   toidentifier@1.0.1: {}
+
+  tough-cookie@4.1.4:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
 
   tr46@0.0.3: {}
 
@@ -5846,6 +6388,8 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
 
+  universalify@0.2.0: {}
+
   unpipe@1.0.0: {}
 
   update-browserslist-db@1.1.3(browserslist@4.25.0):
@@ -5853,6 +6397,11 @@ snapshots:
       browserslist: 4.25.0
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
 
   util-deprecate@1.0.2: {}
 
@@ -5902,7 +6451,7 @@ snapshots:
       '@types/node': 22.15.30
       fsevents: 2.3.3
 
-  vitest@1.6.1(@types/node@22.15.30):
+  vitest@1.6.1(@types/node@22.15.30)(jsdom@24.1.3):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -5926,6 +6475,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.15.30
+      jsdom: 24.1.3
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -5936,11 +6486,21 @@ snapshots:
       - supports-color
       - terser
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@7.0.0: {}
 
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
   whatwg-mimetype@3.0.0: {}
+
+  whatwg-mimetype@4.0.0: {}
 
   whatwg-url@11.0.0:
     dependencies:
@@ -6005,8 +6565,11 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.18.2:
-    optional: true
+  ws@8.18.2: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 
@@ -6040,3 +6603,5 @@ snapshots:
       zen-observable: 0.8.15
 
   zen-observable@0.8.15: {}
+
+  zod@3.25.56: {}


### PR DESCRIPTION
## Summary
- add dynamic form, table, chart and layout components
- create sample pages and Apollo client setup
- implement seed scripts using fishery for all services
- wire up resolvers to in-memory data
- add vitest setup for client and component tests
- update README with usage examples

## Testing
- `pnpm build`
- `pnpm --filter @neo-rewards/auth-service exec vitest run`
- `pnpm --filter @neo-rewards/accounts-service exec vitest run`
- `pnpm --filter @neo-rewards/rewards-service exec vitest run`
- `pnpm --filter @neo-rewards/transfers-service exec vitest run`
- `pnpm --filter @neo-rewards/gateway exec vitest run`
- `pnpm --filter client exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6843f240e61c8331b61519e6f162c17f