### PR TITLE
Improve testing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ pnpm build
 
 Run services individually from their package directories using `pnpm dev`.
 
+## Testing
+Install dependencies before running tests to ensure all packages and
+their binaries are available.
+
+```bash
+pnpm install
+pnpm test
+```
+
+Tests use `mongodb-memory-server` which downloads MongoDB binaries at run time.
+The first run requires network access. If your environment cannot access the
+download servers, supply prebuilt binaries using the `MONGOMS_DOWNLOAD_DIR`
+environment variable.
+
 ## Dynamic UI Components
 
 Example usage for `DynamicForm`:

--- a/packages/accounts-service/README.md
+++ b/packages/accounts-service/README.md
@@ -15,6 +15,7 @@ pnpm dev
 
 ## Testing
 ```bash
+pnpm install
 pnpm test
 ```
 

--- a/packages/auth-service/README.md
+++ b/packages/auth-service/README.md
@@ -16,6 +16,7 @@ pnpm dev
 
 ## Testing
 ```bash
+pnpm install
 pnpm test
 ```
 

--- a/packages/gateway/README.md
+++ b/packages/gateway/README.md
@@ -14,6 +14,7 @@ pnpm dev
 
 ## Testing
 ```bash
+pnpm install
 pnpm test
 ```
 

--- a/packages/rewards-service/README.md
+++ b/packages/rewards-service/README.md
@@ -15,6 +15,7 @@ pnpm dev
 
 ## Testing
 ```bash
+pnpm install
 pnpm test
 ```
 

--- a/packages/transfers-service/README.md
+++ b/packages/transfers-service/README.md
@@ -14,6 +14,7 @@ pnpm dev
 
 ## Testing
 ```bash
+pnpm install
 pnpm test
 ```
 


### PR DESCRIPTION
## Summary
- document test workflow in README
- note `mongodb-memory-server` network requirements
- update package READMEs to install dependencies before tests

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684417814fb88331bd9dbda5a3368bda