### PR TITLE
Fix seed to use factories without ids

### DIFF
--- a/packages/accounts-service/src/data.ts
+++ b/packages/accounts-service/src/data.ts
@@ -1,12 +1,12 @@
 export interface Account {
-  id: string;
+  id?: string;
   userId: string;
   type: string;
   balance: number;
 }
 
 export interface Transaction {
-  id: string;
+  id?: string;
   accountId: string;
   amount: number;
   date: string;

--- a/packages/accounts-service/src/factories/accountFactory.ts
+++ b/packages/accounts-service/src/factories/accountFactory.ts
@@ -1,15 +1,13 @@
 import { Factory } from 'fishery';
-import { Account, Transaction, accounts, transactions } from '../data';
+import { Account, Transaction } from '../data';
 
-export const accountFactory = Factory.define<Account>(({ sequence }) => ({
-  id: sequence.toString(),
+export const accountFactory = Factory.define<Omit<Account, 'id'>>(({ sequence }) => ({
   userId: (sequence % 10).toString(),
   type: ['chequing', 'savings'][sequence % 2],
   balance: 1000 * (sequence % 5),
 }));
 
-export const transactionFactory = Factory.define<Transaction>(({ sequence }) => ({
-  id: sequence.toString(),
+export const transactionFactory = Factory.define<Omit<Transaction, 'id'>>(({ sequence }) => ({
   accountId: (sequence % 10).toString(),
   amount: 50,
   date: new Date().toISOString(),

--- a/packages/accounts-service/src/seed.ts
+++ b/packages/accounts-service/src/seed.ts
@@ -1,3 +1,4 @@
+import { ObjectId } from 'mongodb';
 import { accounts, transactions } from './data';
 import { accountFactory, transactionFactory } from './factories/accountFactory';
 
@@ -5,8 +6,12 @@ export async function seed() {
   accounts.length = 0;
   transactions.length = 0;
   for (let i = 0; i < 100; i++) {
-    accounts.push(accountFactory.build());
-    transactions.push(transactionFactory.build());
+    const accountData = accountFactory.build();
+    const accountId = new ObjectId();
+    accounts.push({ ...accountData, id: accountId.toHexString() });
+
+    const transactionData = transactionFactory.build({ accountId: accountId.toHexString() });
+    transactions.push({ ...transactionData, id: new ObjectId().toHexString() });
   }
 }
 


### PR DESCRIPTION
## Summary
- generate Mongo-style ObjectIds when seeding accounts-service
- allow account and transaction factories to omit `id`
- make `id` optional in account and transaction interfaces

## Testing
- `pnpm test` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844177ce54083319fc546337654c1fb